### PR TITLE
cmake: make PIC optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ include(DefineOptions.cmake)
 include(CPackConfig.cmake)
 include(CompilerChecks.cmake)
 
+# By default builds with -fPIC
+set(CMAKE_POSITION_INDEPENDENT_CODE ${WITH_POSITION_INDEPENDENT_CODE})
+
 # disallow in-source build
 include(MacroEnsureOutOfSourceBuild)
 macro_ensure_out_of_source_build("${PROJECT_NAME} requires an out of source build. Please create a separate build directory and run 'cmake /path/to/${PROJECT_NAME} [options]' there.")

--- a/DefineOptions.cmake
+++ b/DefineOptions.cmake
@@ -3,6 +3,7 @@ option(WITH_CMOCKERY_SUPPORT "Install a cmockery header" OFF)
 option(WITH_EXAMPLES "Build examples" ON)
 option(UNIT_TESTING "Build with unit testing" OFF)
 option(PICKY_DEVELOPER "Build with picky developer flags" OFF)
+option(WITH_POSITION_INDEPENDENT_CODE "Build with PIC/PIE" ON)
 
 if (WITH_STATIC_LIB)
     set(BUILD_STATIC_LIB ON)

--- a/cmake/Modules/DefineCMakeDefaults.cmake
+++ b/cmake/Modules/DefineCMakeDefaults.cmake
@@ -16,6 +16,3 @@ set(CMAKE_COLOR_MAKEFILE ON)
 
 # Create the compile command database for clang by default
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-# Always build with -fPIC
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Some embedded compilers cannot compile CMake's test program with PIC.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>