### PR TITLE
cmake: optional shared lib build

### DIFF
--- a/DefineOptions.cmake
+++ b/DefineOptions.cmake
@@ -1,4 +1,5 @@
 option(WITH_STATIC_LIB "Build with a static library" OFF)
+option(WITH_SHARED_LIB "Build with a shared library" ON)
 option(WITH_CMOCKERY_SUPPORT "Install a cmockery header" OFF)
 option(WITH_EXAMPLES "Build examples" ON)
 option(UNIT_TESTING "Build with unit testing" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,10 +3,12 @@ project(cmocka-library C)
 set(CMOCKA_PLATFORM_INCLUDE CACHE PATH "Path to include directory for cmocka_platform.h")
 mark_as_advanced(CMOCKA_PLATFORM_INCLUDE)
 
-set(CMOCKA_SHARED_LIBRARY
-    cmocka
-    CACHE INTERNAL "cmocka shared library"
-)
+if (WITH_SHARED_LIB)
+    set(CMOCKA_SHARED_LIBRARY
+        cmocka
+        CACHE INTERNAL "cmocka shared library"
+    )
+endif()
 
 if (BUILD_STATIC_LIB)
     set(CMOCKA_STATIC_LIBRARY
@@ -31,57 +33,59 @@ if (WIN32)
     )
 endif (WIN32)
 
-add_library(${CMOCKA_SHARED_LIBRARY} SHARED ${cmocka_SRCS})
+if (WITH_SHARED_LIB)
+    add_library(${CMOCKA_SHARED_LIBRARY} SHARED ${cmocka_SRCS})
 
-target_include_directories(${CMOCKA_SHARED_LIBRARY}
-                           PRIVATE
-                               ${CMOCKA_PLATFORM_INCLUDE}
-                               ${cmocka_BINARY_DIR}
-                           PUBLIC
-                               ${cmocka-header_SOURCE_DIR})
+    target_include_directories(${CMOCKA_SHARED_LIBRARY}
+                            PRIVATE
+                                ${CMOCKA_PLATFORM_INCLUDE}
+                                ${cmocka_BINARY_DIR}
+                            PUBLIC
+                                ${cmocka-header_SOURCE_DIR})
 
 
-target_compile_options(${CMOCKA_SHARED_LIBRARY}
-                       PRIVATE
-                           ${DEFAULT_C_COMPILE_FLAGS}
-                           -DHAVE_CONFIG_H)
-if (CMOCKA_PLATFORM_INCLUDE)
     target_compile_options(${CMOCKA_SHARED_LIBRARY}
-                           PRIVATE
-                               -DCMOCKA_PLATFORM_INCLUDE)
-endif()
+                        PRIVATE
+                            ${DEFAULT_C_COMPILE_FLAGS}
+                            -DHAVE_CONFIG_H)
+    if (CMOCKA_PLATFORM_INCLUDE)
+        target_compile_options(${CMOCKA_SHARED_LIBRARY}
+                            PRIVATE
+                                -DCMOCKA_PLATFORM_INCLUDE)
+    endif()
 
-target_link_libraries(${CMOCKA_SHARED_LIBRARY} ${CMOCKA_LINK_LIBRARIES})
-set_property(TARGET
-                 ${CMOCKA_SHARED_LIBRARY}
-             PROPERTY
-                 DEFINE_SYMBOL
-                     CMOCKA_EXPORTS
-             PROPERTY
-                 LINKER_FLAGS
-                     "${DEFAULT_LINK_FLAGS}")
+    target_link_libraries(${CMOCKA_SHARED_LIBRARY} ${CMOCKA_LINK_LIBRARIES})
+    set_property(TARGET
+                    ${CMOCKA_SHARED_LIBRARY}
+                PROPERTY
+                    DEFINE_SYMBOL
+                        CMOCKA_EXPORTS
+                PROPERTY
+                    LINKER_FLAGS
+                        "${DEFAULT_LINK_FLAGS}")
 
-if (NOT WIN32)
-    set_target_properties(
-        ${CMOCKA_SHARED_LIBRARY}
-            PROPERTIES
-                VERSION
-                    ${LIBRARY_VERSION}
-                SOVERSION
-                    ${LIBRARY_SOVERSION}
-    )
-endif (NOT WIN32)
-
-install(TARGETS
+    if (NOT WIN32)
+        set_target_properties(
             ${CMOCKA_SHARED_LIBRARY}
-        ARCHIVE DESTINATION
-            ${CMAKE_INSTALL_LIBDIR}
-        LIBRARY DESTINATION
-            ${CMAKE_INSTALL_LIBDIR}
-        RUNTIME DESTINATION
-            ${CMAKE_INSTALL_BINDIR}
-        COMPONENT
-            ${PROJECT_NAME})
+                PROPERTIES
+                    VERSION
+                        ${LIBRARY_VERSION}
+                    SOVERSION
+                        ${LIBRARY_SOVERSION}
+        )
+    endif (NOT WIN32)
+
+    install(TARGETS
+                ${CMOCKA_SHARED_LIBRARY}
+            ARCHIVE DESTINATION
+                ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION
+                ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION
+                ${CMAKE_INSTALL_BINDIR}
+            COMPONENT
+                ${PROJECT_NAME})
+endif (WITH_SHARED_LIB)
 
 if (BUILD_STATIC_LIB)
     add_library(${CMOCKA_STATIC_LIBRARY} STATIC ${cmocka_SRCS})


### PR DESCRIPTION
For compilers that cannot build shared libs and still want to use make / make install for making prebuilt libs

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>